### PR TITLE
Release 2020-03-30

### DIFF
--- a/src/api/extensions/icmaa-cms/README.md
+++ b/src/api/extensions/icmaa-cms/README.md
@@ -19,7 +19,9 @@ This API extension get data from headless cms of choice.
          "fallbackLanguage": "de-de"
        },
        "storyblok": {
+         "spaceId": "XXXXX",
          "accessToken": "XXXXXXXXXXXXXXXXXXXXXXXX",
+         "defaultLanguageCodes": [ "default", "en" ],
          "pluginFieldMap": [
           { "key": "icmaa-single-option", "values": [ "selected" ] },
           { "key": "icmaa-multi-option", "values": [ "selected" ] },

--- a/src/api/extensions/icmaa-cms/connector/storyblok.ts
+++ b/src/api/extensions/icmaa-cms/connector/storyblok.ts
@@ -90,7 +90,8 @@ class StoryblokConnector {
   }
 
   public matchLanguage (lang) {
-    lang = lang && lang !== 'default' ? lang.toLowerCase() : false
+    const defaultLanguageCodes: string[] = config.get('extensions.icmaaCms.storyblok.defaultLanguageCodes')
+    lang = lang && !defaultLanguageCodes.includes(lang) ? lang.toLowerCase() : false
     this.lang = lang && config.get('icmaa.mandant') ? `${config.get('icmaa.mandant')}_${lang}` : lang
     return this.lang
   }

--- a/src/api/extensions/icmaa-cms/helpers/formatter/storyblok.ts
+++ b/src/api/extensions/icmaa-cms/helpers/formatter/storyblok.ts
@@ -1,4 +1,5 @@
 import pick from 'lodash/pick'
+import forEach from 'lodash/forEach'
 import config from 'config'
 import StoryblokClient from 'storyblok-js-client'
 
@@ -39,5 +40,13 @@ export const extractStoryContent = (object) => {
       content[f] = object[f]
     }
   })
+
+  const regex = /^group_[\w]/
+  forEach(content, (v, k) => {
+    if (regex.exec(k) !== null) {
+      delete content[k]
+    }
+  })
+
   return content
 }


### PR DESCRIPTION
* `icmaa-cms` // Add a config array for language codes which should map to `default` in Storyblok (#44)
* Strip empty group fields of Storyblok response in `icmaa-cms` formatter (#45)