### PR TITLE
Release 2020-10-09

### DIFF
--- a/src/api/attribute/service.ts
+++ b/src/api/attribute/service.ts
@@ -62,7 +62,8 @@ async function setAttributeInCache (attributeList, config) {
       await Promise.all(
         attributeList.map(attribute => (cache as TagCache).set(
           'api:attribute-list' + attribute.attribute_code,
-          attribute
+          attribute,
+          []
         ))
       )
     } catch (err) {

--- a/src/api/extensions/icmaa-catalog/filter/catalog/ActiveByDateRangeFilter.ts
+++ b/src/api/extensions/icmaa-catalog/filter/catalog/ActiveByDateRangeFilter.ts
@@ -1,0 +1,51 @@
+import config from 'config'
+import { FilterInterface } from 'storefront-query-builder'
+import omit from 'lodash/omit'
+
+const defaultFields = config.get<{ from: string, to: string }>('extensions.icmaa-catalog.defaultDateRangeFields')
+
+const filter: FilterInterface = {
+  priority: 1,
+  check: ({ attribute }) => attribute === 'activeDateRange',
+  filter ({ queryChain, value }) {
+    // Empty values populated as `{ "in": "" }` – this would crash our query.
+    if (Object.keys(value).length === 1 && value.hasOwnProperty('in')) {
+      value = {}
+    }
+
+    const fromField = value.fromField || defaultFields.from
+    const toField = value.toField || defaultFields.to
+
+    value = omit(value, ['fromField', 'toField'])
+
+    queryChain.filter('bool', rangeQuery => {
+      rangeQuery
+        // From
+        .filter('bool', rangeFromQuery => {
+          return rangeFromQuery
+            .orFilter('bool', rangeFromEmptyQuery => {
+              return rangeFromEmptyQuery.notFilter('exists', fromField)
+            })
+            .orFilter('range', fromField, {
+              ...Object.assign({}, { 'lte': 'now' }, value)
+            })
+        })
+        // To
+        .filter('bool', rangeToQuery => {
+          return rangeToQuery
+            .orFilter('bool', rangeToEmptyQuery => {
+              return rangeToEmptyQuery.notFilter('exists', toField)
+            })
+            .orFilter('range', toField, {
+              ...Object.assign({}, { 'gte': 'now' }, value)
+            })
+        })
+
+      return rangeQuery
+    })
+
+    return queryChain
+  }
+}
+
+export default filter


### PR DESCRIPTION
* #201651 Add custom `ActiveByDateRange` filter to `icmaa-catalog` module (#112)
  * This filter is used to fetch only products/categories in a specific date-range or `null`
* Fix exception and add category cache-tags to product queries (#113)
  * Prevent exception in `redis-tag-cache` when tags are empty
  * Add cache-tags for categories in product queries to be able to flush product-lists by category id
* #201651 Add UTC offset option to `ActiveByDateRangeFilter` (#114)